### PR TITLE
Star 1275 pass client SRT version and latency to connected callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include(ExternalProject)
 ExternalProject_Add(project_srt
         GIT_REPOSITORY https://github.com/Haivision/srt.git
         #  We use the git commit hash because it is faster
-        GIT_TAG 0bc3b03202b3159fc9b085b3ae6d66ec071c25d6 # v1.5.1
+        GIT_TAG 09f35c0f1743e23f514cb41444504a7faeacf89e # v1.5.3
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/srt
         BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/srt
         CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/srt/configure --CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -31,7 +31,8 @@ ExternalProject_Add(project_srt
 
 ExternalProject_Add(project_srt_win
         GIT_REPOSITORY https://github.com/Haivision/srt.git
-        GIT_TAG v1.5.1
+        #  We use the git commit hash because it is faster
+        GIT_TAG 09f35c0f1743e23f514cb41444504a7faeacf89e #v1.5.3
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/srt
         BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/srt
         CONFIGURE_COMMAND cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DENABLE_STDCXX_SYNC=ON ${CMAKE_CURRENT_SOURCE_DIR}/srt

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -220,8 +220,11 @@ void SRTNet::serverEventHandler(bool singleClient) {
             }
         }
 
-        if (singleClient && mClientList.empty()) {
-            break;
+        {
+            std::lock_guard<std::mutex> lock(mClientListMtx);
+            if (singleClient && mClientList.empty()) {
+                break;
+            }
         }
     }
     SRT_LOGGER(true, LOGG_NOTIFY, "serverEventHandler exit");

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -347,10 +347,22 @@ bool SRTNet::waitForSRTClient(bool singleClient) {
     return false;
 }
 
-void SRTNet::getActiveClients(
-    const std::function<void(std::map<SRTSOCKET, std::shared_ptr<NetworkConnection>>&)>& function) {
+std::vector<std::pair<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>>> SRTNet::getActiveClients() const {
     std::lock_guard<std::mutex> lock(mClientListMtx);
-    function(mClientList);
+
+    std::vector<std::pair<SRTSOCKET, std::shared_ptr<NetworkConnection>>> clients;
+    std::copy(mClientList.begin(), mClientList.end(), std::back_inserter(clients));
+    return clients;
+}
+
+std::vector<SRTSOCKET> SRTNet::getActiveClientSockets() const {
+    std::lock_guard<std::mutex> lock(mClientListMtx);
+
+    std::vector<SRTSOCKET> clientSockets(mClientList.size());
+    for (const auto& [socket, networkConnection] : mClientList) {
+        clientSockets.push_back(socket);
+    }
+    return clientSockets;
 }
 
 bool SRTNet::startClient(const std::string& host,

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -354,7 +354,6 @@ bool SRTNet::startClient(const std::string& host,
     }
 
     
-    SRT_LOGGER(true, LOGG_ERROR, "SRT connect");
     for (struct addrinfo* resolvedAddress = resolvedAddresses;
          resolvedAddress != nullptr;
          resolvedAddress = resolvedAddress->ai_next) {
@@ -362,7 +361,7 @@ bool SRTNet::startClient(const std::string& host,
                              reinterpret_cast<sockaddr*>(resolvedAddress->ai_addr),
                              resolvedAddress->ai_addrlen);
         if (result != SRT_ERROR) {
-            SRT_LOGGER(true, LOGG_ERROR, "Connected to SRT Server " << std::endl)
+            SRT_LOGGER(true, LOGG_NOTIFY, "Connected to SRT Server " << std::endl)
             mClientConnected = true;
             break;
         }

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -345,6 +345,63 @@ bool SRTNet::startClient(const std::string& host,
 
     mClientContext = ctx;
 
+    mCallerLocalHost = localHost;
+    mCallerLocalPort = localPort;
+    mCallerReorder = reorder;
+    mCallerLatency = latency;
+    mCallerOverhead = overhead;
+    mCallerMtu = mtu;
+    mCallerPeerIdleTimeout = peerIdleTimeout;
+    mCallerPsk = psk;
+
+    if (!createClientSocket()) {
+        SRT_LOGGER(true, LOGG_ERROR, "Failed to create caller socket");
+        return false;
+
+    }
+    mCallerHost = host;
+    mCallerPort = port;
+
+    // Get all remote addresses for connection
+    struct addrinfo hints = {0};
+    struct addrinfo* svr;
+    struct addrinfo* hld;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_protocol = IPPROTO_UDP;
+    hints.ai_family = AF_UNSPEC;
+    std::stringstream portAsString;
+    portAsString << port;
+    int result = getaddrinfo(host.c_str(), portAsString.str().c_str(), &hints, &svr);
+    if (result) {
+        SRT_LOGGER(true, LOGG_FATAL,
+                   "Failed getting the IP target for > " << host << ":" << port << " Errno: " << result);
+        return false;
+    }
+
+    
+    SRT_LOGGER(true, LOGG_ERROR, "SRT connect");
+    for (hld = svr; hld; hld = hld->ai_next) {
+        result = srt_connect(mContext, reinterpret_cast<sockaddr*>(hld->ai_addr), hld->ai_addrlen);
+        if (result != SRT_ERROR) {
+            SRT_LOGGER(true, LOGG_ERROR, "Connected to SRT Server " << std::endl)
+            mClientConnected = true;
+            break;
+        }
+    }
+    freeaddrinfo(svr);
+    if (result == SRT_ERROR) {
+        srt_close(mContext);
+        SRT_LOGGER(true, LOGG_FATAL, "srt_connect failed " << std::endl);
+    }
+
+    mCurrentMode = Mode::client;
+    mClientActive = true;
+    mWorkerThread = std::thread(&SRTNet::clientWorker, this);
+
+    return true;
+}
+
+bool SRTNet::createClientSocket() {
     int result = 0;
     int32_t yes = 1;
     SRT_LOGGER(true, LOGG_NOTIFY, "SRT client startup");
@@ -361,31 +418,31 @@ bool SRTNet::startClient(const std::string& host,
         return false;
     }
 
-    result = srt_setsockflag(mContext, SRTO_LATENCY, &latency, sizeof(latency));
+    result = srt_setsockflag(mContext, SRTO_LATENCY, &mCallerLatency, sizeof(mCallerLatency));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_LATENCY: " << srt_getlasterror_str());
         return false;
     }
 
-    result = srt_setsockflag(mContext, SRTO_LOSSMAXTTL, &reorder, sizeof(reorder));
+    result = srt_setsockflag(mContext, SRTO_LOSSMAXTTL, &mCallerReorder, sizeof(mCallerReorder));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_LOSSMAXTTL: " << srt_getlasterror_str());
         return false;
     }
 
-    result = srt_setsockflag(mContext, SRTO_OHEADBW, &overhead, sizeof(overhead));
+    result = srt_setsockflag(mContext, SRTO_OHEADBW, &mCallerOverhead, sizeof(mCallerOverhead));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_OHEADBW: " << srt_getlasterror_str());
         return false;
     }
 
-    result = srt_setsockflag(mContext, SRTO_PAYLOADSIZE, &mtu, sizeof(mtu));
+    result = srt_setsockflag(mContext, SRTO_PAYLOADSIZE, &mCallerMtu, sizeof(mCallerMtu));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_PAYLOADSIZE: " << srt_getlasterror_str());
         return false;
     }
 
-    if (psk.length()) {
+    if (mCallerPsk.length()) {
         int32_t aes128 = 16;
         result = srt_setsockflag(mContext, SRTO_PBKEYLEN, &aes128, sizeof(aes128));
         if (result == SRT_ERROR) {
@@ -393,30 +450,37 @@ bool SRTNet::startClient(const std::string& host,
             return false;
         }
 
-        result = srt_setsockflag(mContext, SRTO_PASSPHRASE, psk.c_str(), psk.length());
+        result = srt_setsockflag(mContext, SRTO_PASSPHRASE, mCallerPsk.c_str(), mCallerPsk.length());
         if (result == SRT_ERROR) {
             SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_PASSPHRASE: " << srt_getlasterror_str());
             return false;
         }
     }
 
-    result = srt_setsockflag(mContext, SRTO_PEERIDLETIMEO, &peerIdleTimeout, sizeof(peerIdleTimeout));
+    result = srt_setsockflag(mContext, SRTO_PEERIDLETIMEO, &mCallerPeerIdleTimeout, sizeof(mCallerPeerIdleTimeout));
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag : SRTO_PEERIDLETIMEO" << srt_getlasterror_str());
         return false;
     }
 
-    if (!localHost.empty() || localPort != 0) {
+    const int connection_timeout_ms = 1000;
+    result = srt_setsockopt(mContext, 0, SRTO_CONNTIMEO, &connection_timeout_ms, sizeof connection_timeout_ms);
+    if (result == SRT_ERROR) {
+        SRT_LOGGER(true, LOGG_FATAL, "srt_setsockopt: SRTO_CONNTIMEO" << srt_getlasterror_str());
+        return false;
+    }
+
+    if (!mCallerLocalHost.empty() || mCallerLocalPort != 0) {
         // Set local interface to bind to
 
-        if (localHost.empty()) {
+        if (mCallerLocalHost.empty()) {
             SRT_LOGGER(true, LOGG_FATAL,
                        "Local port was provided but local IP is not set, cannot bind to local address");
             srt_close(mContext);
             return false;
         }
 
-        SocketAddress localSocketAddress(localHost, localPort);
+        SocketAddress localSocketAddress(mCallerLocalHost, mCallerLocalPort);
 
         std::optional<sockaddr_in> localIPv4Address = localSocketAddress.getIPv4();
         if (localIPv4Address.has_value()) {
@@ -447,56 +511,65 @@ bool SRTNet::startClient(const std::string& host,
         }
     }
 
-    // Get all remote addresses for connection
-    struct addrinfo hints = {0};
-    struct addrinfo* svr;
-    struct addrinfo* hld;
-    hints.ai_socktype = SOCK_DGRAM;
-    hints.ai_protocol = IPPROTO_UDP;
-    hints.ai_family = AF_UNSPEC;
-    std::stringstream portAsString;
-    portAsString << port;
-    result = getaddrinfo(host.c_str(), portAsString.str().c_str(), &hints, &svr);
-    if (result) {
-        SRT_LOGGER(true, LOGG_FATAL,
-                   "Failed getting the IP target for > " << host << ":" << port << " Errno: " << result);
-        return false;
-    }
-
-    SRT_LOGGER(true, LOGG_NOTIFY, "SRT connect");
-    for (hld = svr; hld; hld = hld->ai_next) {
-        result = srt_connect(mContext, reinterpret_cast<sockaddr*>(hld->ai_addr), hld->ai_addrlen);
-        if (result != SRT_ERROR) {
-            SRT_LOGGER(true, LOGG_NOTIFY, "Connected to SRT Server " << std::endl)
-            break;
-        }
-    }
-    if (result == SRT_ERROR) {
-        srt_close(mContext);
-        freeaddrinfo(svr);
-        SRT_LOGGER(true, LOGG_FATAL, "srt_connect failed " << std::endl);
-        return false;
-    }
-    freeaddrinfo(svr);
-    mCurrentMode = Mode::client;
-    mClientActive = true;
-    mWorkerThread = std::thread(&SRTNet::clientWorker, this);
     return true;
 }
 
 void SRTNet::clientWorker() {
     while (mClientActive) {
+        if (!mClientConnected) {
+            // Get all remote addresses for connection
+            struct addrinfo hints = {0};
+            struct addrinfo* svr;
+            struct addrinfo* hld;
+            hints.ai_socktype = SOCK_DGRAM;
+            hints.ai_protocol = IPPROTO_UDP;
+            hints.ai_family = AF_UNSPEC;
+            std::stringstream portAsString;
+            portAsString << mCallerPort;
+            int result = getaddrinfo(mCallerHost.c_str(), portAsString.str().c_str(), &hints, &svr);
+            if (result) {
+                SRT_LOGGER(true, LOGG_FATAL,
+                        "Failed getting the IP target for > " << mCallerHost << ":" << mCallerPort << " Errno: " << result);
+                break;
+            }
+
+            //TODO SRT_LOGGER(true, LOGG_ERROR, "SRT connect");
+            for (hld = svr; hld; hld = hld->ai_next) {
+                result = srt_connect(mContext, reinterpret_cast<sockaddr*>(hld->ai_addr), hld->ai_addrlen);
+                if (result != SRT_ERROR) {
+                    SRT_LOGGER(true, LOGG_ERROR, "Connected to SRT Server " << std::endl)
+                    mClientConnected = true;
+                    // Break for-loop on first successfull connect call
+                    break;
+                }
+            }
+            freeaddrinfo(svr);
+            if (result == SRT_ERROR) {
+                // Failed to connect caller/client, try again, the connect call waited some time before
+                // giving up
+                //TODO SRT_LOGGER(true, LOGG_FATAL, "srt_connect failed " << std::endl);
+                continue;
+            }
+        }
+
         uint8_t msg[2048];
         SRT_MSGCTRL thisMSGCTRL = srt_msgctrl_default;
         int result = srt_recvmsg2(mContext, reinterpret_cast<char*>(msg), sizeof(msg), &thisMSGCTRL);
         if (result == SRT_ERROR) {
+            mClientConnected = false;
+
+            SRTSOCKET context = mContext;
             if (mClientActive) {
                 SRT_LOGGER(true, LOGG_ERROR, "srt_recvmsg error: " << srt_getlasterror_str());
+                srt_close(mContext);
+                if (!createClientSocket()) {
+                    SRT_LOGGER(true, LOGG_ERROR, "Failed to re-create caller socket");
+                    break;
+                }
             }
             if (clientDisconnected) {
-                clientDisconnected(mClientContext, mContext);
+                clientDisconnected(mClientContext, context);
             }
-            break;
         } else if (result > 0 && receivedData) {
             auto data = std::make_unique<std::vector<uint8_t>>(msg, msg + result);
             receivedData(data, thisMSGCTRL, mClientContext, mContext);
@@ -505,6 +578,11 @@ void SRTNet::clientWorker() {
         }
     }
     mClientActive = false;
+/*    mCurrentMode = Mode::unknown;
+    mClientContext = nullptr;
+    srt_close(mContext);
+    mContext = 0;
+    */
 }
 
 std::pair<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> SRTNet::getConnectedServer() {
@@ -512,6 +590,10 @@ std::pair<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> SRTNet::getConn
         return {mContext, mClientContext};
     }
     return {0, nullptr};
+}
+
+bool SRTNet::isClientConnected() const {
+    return mClientConnected;
 }
 
 SRTSOCKET SRTNet::getBoundSocket() const {
@@ -538,7 +620,7 @@ void SRTNet::setLogHandler(SRT_LOG_HANDLER_FN* handler, int loglevel) {
 bool SRTNet::sendData(const uint8_t* data, size_t len, SRT_MSGCTRL* msgCtrl, SRTSOCKET targetSystem) {
     int result;
 
-    if (mCurrentMode == Mode::client && mContext && mClientActive) {
+    if (mCurrentMode == Mode::client && mContext && mClientActive && mClientConnected) {
         result = srt_sendmsg2(mContext, reinterpret_cast<const char*>(data), len, msgCtrl);
     } else if (mCurrentMode == Mode::server && targetSystem && mServerActive) {
         result = srt_sendmsg2(targetSystem, reinterpret_cast<const char*>(data), len, msgCtrl);
@@ -604,6 +686,10 @@ bool SRTNet::stop() {
 bool SRTNet::getStatistics(SRT_TRACEBSTATS* currentStats, int clear, int instantaneous, SRTSOCKET targetSystem) {
     std::lock_guard<std::mutex> lock(mNetMtx);
     if (mCurrentMode == Mode::client && mClientActive && mContext) {
+        if (!mClientConnected) {
+            memset(currentStats, 0, sizeof(SRT_TRACEBSTATS));
+            return true;
+        }
         int result = srt_bistats(mContext, currentStats, clear, instantaneous);
         if (result == SRT_ERROR) {
             SRT_LOGGER(true, LOGG_ERROR, "srt_bistats failed: " << srt_getlasterror_str());

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -460,6 +460,14 @@ bool SRTNet::createServerSocket() {
 
     std::optional<sockaddr_in6> ipv6Address = socketAddress.getIPv6();
     if (ipv6Address.has_value()) {
+        if (mConfiguration.mLocalHost == "::") {
+            result = srt_setsockflag(mContext, SRTO_IPV6ONLY, &yes, sizeof(yes));
+            if (result == SRT_ERROR) {
+                SRT_LOGGER(true, LOGG_FATAL, "srt_setsockflag SRTO_IPV6ONLY: " << srt_getlasterror_str());
+                return false;
+            }
+        }
+
         result = srt_bind(mContext, reinterpret_cast<sockaddr*>(&ipv6Address.value()), sizeof(ipv6Address.value()));
         if (result == SRT_ERROR) {
             SRT_LOGGER(true, LOGG_FATAL, "srt_bind: " << srt_getlasterror_str());

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -292,9 +292,10 @@ bool SRTNet::startClient(const std::string& host,
                          int overhead,
                          std::shared_ptr<NetworkConnection>& ctx,
                          int mtu,
+                         bool failOnConnectionError,
                          int32_t peerIdleTimeout,
                          const std::string& psk) {
-    return startClient(host, port, "", 0, reorder, latency, overhead, ctx, mtu, peerIdleTimeout, psk);
+    return startClient(host, port, "", 0, reorder, latency, overhead, ctx, mtu, failOnConnectionError, peerIdleTimeout, psk);
 }
 
 // Host can provide a IP or name meaning any IPv4 or IPv6 address or name type www.google.com
@@ -308,6 +309,7 @@ bool SRTNet::startClient(const std::string& host,
                          int overhead,
                          std::shared_ptr<NetworkConnection>& ctx,
                          int mtu,
+                         bool failOnConnectionError,
                          int32_t peerIdleTimeout,
                          const std::string& psk) {
     std::lock_guard<std::mutex> lock(mNetMtx);
@@ -370,7 +372,8 @@ bool SRTNet::startClient(const std::string& host,
     if (result == SRT_ERROR) {
         SRT_LOGGER(true, LOGG_FATAL, "srt_connect failed: " << srt_getlasterror_str() << std::endl);
         int rejectReason = srt_getrejectreason(mContext);
-        if (rejectReason == SRT_REJECT_REASON::SRT_REJ_BADSECRET ||
+        if (failOnConnectionError ||
+            rejectReason == SRT_REJECT_REASON::SRT_REJ_BADSECRET ||
             rejectReason == SRT_REJECT_REASON::SRT_REJ_UNSECURE) {
             srt_close(mContext);
             return false;

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -361,7 +361,8 @@ std::vector<std::pair<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>>> SR
 std::vector<SRTSOCKET> SRTNet::getActiveClientSockets() const {
     std::lock_guard<std::mutex> lock(mClientListMtx);
 
-    std::vector<SRTSOCKET> clientSockets(mClientList.size());
+    std::vector<SRTSOCKET> clientSockets;
+    clientSockets.reserve(mClientList.size());
     for (const auto& [socket, networkConnection] : mClientList) {
         clientSockets.push_back(socket);
     }

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -256,6 +256,9 @@ SRTNet::ClientConnectStatus SRTNet::clientConnectToServer() {
                              resolvedAddress->ai_addrlen);
         if (result != SRT_ERROR) {
             mClientConnected = true;
+            if (connectedToServer) {
+                connectedToServer(mConnectionContext, mContext);
+            }
             // Break for-loop on first successful connect call
             break;
         }

--- a/SRTNet.cpp
+++ b/SRTNet.cpp
@@ -72,6 +72,10 @@ SRTNet::SRTNet() {
     SRT_LOGGER(true, LOGG_NOTIFY, "SRTNet constructed");
 }
 
+SRTNet::SRTNet(SRT_LOG_HANDLER_FN* handler, int loglevel) {
+    setLogHandler(handler, loglevel);
+}
+
 SRTNet::~SRTNet() {
     stop();
     SRT_LOGGER(true, LOGG_NOTIFY, "SRTNet destruct")
@@ -518,6 +522,18 @@ SRTNet::Mode SRTNet::getCurrentMode() const {
     std::lock_guard<std::mutex> lock(mNetMtx);
     return mCurrentMode;
 }
+
+void SRTNet::defaultLogHandler(void* opaque, int level, const char* file, int line, const char* area, const char* message) {
+    std::cout << message << std::endl;
+}
+
+void SRTNet::setLogHandler(SRT_LOG_HANDLER_FN* handler, int loglevel) {
+    logHandler = handler;
+    srt_setloghandler(nullptr, handler);
+    srt_setlogflags(SRT_LOGF_DISABLE_TIME | SRT_LOGF_DISABLE_THREADNAME | SRT_LOGF_DISABLE_SEVERITY | SRT_LOGF_DISABLE_EOL);
+    srt_setloglevel(loglevel);
+}
+
 
 bool SRTNet::sendData(const uint8_t* data, size_t len, SRT_MSGCTRL* msgCtrl, SRTSOCKET targetSystem) {
     int result;

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -303,6 +303,9 @@ public:
     /// Callback handling disconnecting clients (server and client mode)
     std::function<void(std::shared_ptr<NetworkConnection>& ctx, SRTSOCKET lSocket)> clientDisconnected = nullptr;
 
+    /// Callback called whenever the client gets connected to the server (client mode only)
+    std::function<void(std::shared_ptr<NetworkConnection>& ctx, SRTSOCKET lSocket)> connectedToServer = nullptr;
+
     // delete copy and move constructors and assign operators
     SRTNet(SRTNet const&) = delete;            // Copy construct
     SRTNet(SRTNet&&) = delete;                 // Move construct

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -244,6 +244,16 @@ public:
 
     /**
      *
+     * @brief Get the bound port of the instance. Useful if the local port was 0 when starting the client or server. In
+     * these cases the SRT library will automatically assign a port and this function will then return which port
+     * is being used.
+     * @returns The bound port of the instance in case it has been assigned, otherwise 0.
+     *
+     */
+    uint16_t getLocallyBoundPort() const;
+
+    /**
+     *
      * @brief Get the current operating mode.
      * @returns The operating mode.
      *

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -205,13 +205,19 @@ public:
 
     /**
      *
-     * Get active clients (A server method)
+     * @brief Get all active clients (A server method)
+     * @return A vector of pairs containing the SRTSocketHandle (SRTSOCKET) and it's associated NetworkConnection.
      *
-     * @param function. pass a function getting the map containing the list of active connections
-     * Where the map contains the SRTSocketHandle (SRTSOCKET) and it's associated NetworkConnection you provided.
      */
-    void
-    getActiveClients(const std::function<void(std::map<SRTSOCKET, std::shared_ptr<NetworkConnection>>&)>& function);
+    std::vector<std::pair<SRTSOCKET, std::shared_ptr<NetworkConnection>>> getActiveClients() const;
+
+    /**
+     *
+     * @brief Get the socket of all active clients (A server method)
+     * @return A vector containing the SRTSocketHandle (SRTSOCKET) of all active clients.
+     *
+     */
+    std::vector<SRTSOCKET> getActiveClientSockets() const;
 
     /**
      *
@@ -428,7 +434,7 @@ private:
     mutable std::mutex mNetMtx;
     Mode mCurrentMode = Mode::unknown;
     std::map<SRTSOCKET, std::shared_ptr<NetworkConnection>> mClientList = {};
-    std::mutex mClientListMtx;
+    mutable std::mutex mClientListMtx;
     std::shared_ptr<NetworkConnection> mClientContext = nullptr;
     std::shared_ptr<NetworkConnection> mConnectionContext = nullptr;
     std::atomic<bool> mClientConnected = false;

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -144,7 +144,7 @@ public:
      * @param peerIdleTimeout Optional Connection considered broken if no packet received before this timeout.
      * Defaults to 5 seconds.
      * @param psk Optional Pre Shared Key (AES-128)
-     * @return true if client was able to connect to the server
+     * @return true if configuration was ok and remote IP port could be resolved, false otherwise
      */
     bool startClient(const std::string& host,
                      uint16_t port,
@@ -210,6 +210,13 @@ public:
      *
      */
     std::pair<SRTSOCKET, std::shared_ptr<NetworkConnection>> getConnectedServer();
+
+    /**
+     * 
+     * @brief Check if client is connected to remote end
+     * @returns True is client is connected to the the remote end, false otherwise
+    */
+    bool isClientConnected() const;
 
     /**
      *
@@ -289,6 +296,8 @@ private:
 
     void closeAllClientSockets();
 
+    bool createClientSocket();
+
     SRT_LOG_HANDLER_FN* logHandler = defaultLogHandler;
 
     // Server active? true == yes
@@ -307,4 +316,16 @@ private:
     std::mutex mClientListMtx;
     std::shared_ptr<NetworkConnection> mClientContext = nullptr;
     std::shared_ptr<NetworkConnection> mConnectionContext = nullptr;
+    std::atomic<bool> mClientConnected = false;
+    std::string mCallerHost;
+    uint16_t mCallerPort;
+
+    std::string mCallerLocalHost;
+    uint16_t mCallerLocalPort;
+    int mCallerReorder;
+    int32_t mCallerLatency;
+    int mCallerOverhead;
+    int mCallerMtu;
+    int32_t mCallerPeerIdleTimeout;
+    std::string mCallerPsk;
 };

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -104,8 +104,9 @@ public:
 
     /**
      *
-     * Starts an SRT Client and connects to the server. If the server is currently not listening for connections, the
-     * client will keep on trying to re-connect.
+     * Starts an SRT Client and connects to the server. If the server is currently not listening for connections, or the
+     * client can't reach the server over the network, the client may keep on trying to re-connect or fail to start
+     * depending on the value or \p failOnConnectionError.
      *
      * @param host Remote host IP or hostname
      * @param port Remote host Port
@@ -114,6 +115,10 @@ public:
      * @param overhead % extra of the BW that will be allowed for re-transmission packets
      * @param ctx the context used in the receivedData and receivedDataNoCopy callback
      * @param mtu sets the MTU
+     * @param failOnConnectionError if set to true and the initial connection attempt to the server fails this function
+     * will return false, if set to false the client will start an internal thread that will keep on trying to connect
+     * to the server until stop() is called. If the initial connection attempt is successful, the client will always
+     * try to re-connect to the server in case the client gets disconnected.
      * @param peerIdleTimeout Optional Connection considered broken if no packet received before this timeout.
      * Defaults to 5 seconds.
      * @param psk Optional Pre Shared Key (AES-128)
@@ -127,13 +132,15 @@ public:
                      int overhead,
                      std::shared_ptr<NetworkConnection>& ctx,
                      int mtu,
+                     bool failOnConnectionError,
                      int32_t peerIdleTimeout = 5000,
                      const std::string& psk = "");
 
     /**
      *
      * Starts an SRT Client with a specified local address to bind to and connects to the server. If the server is
-     * currently not listening for connections, the client will keep on trying to re-connect.
+     * currently not listening for connections, or the client can't reach the server over the network, the client may
+     * keep on trying to re-connect or fail to start depending on the value or \p failOnConnectionError.
      *
      * @param host Remote host IP or hostname to connect to
      * @param port Remote host port to connect to
@@ -144,6 +151,10 @@ public:
      * @param overhead % extra of the BW that will be allowed for re-transmission packets
      * @param ctx the context used in the receivedData and receivedDataNoCopy callback
      * @param mtu sets the MTU
+     * @param failOnConnectionError if set to true and the initial connection attempt to the server fails this function
+     * will return false, if set to false the client will start an internal thread that will keep on trying to connect
+     * to the server until stop() is called. If the initial connection attempt is successful, the client will always
+     * try to re-connect to the server in case the client gets disconnected.
      * @param peerIdleTimeout Optional Connection considered broken if no packet received before this timeout.
      * Defaults to 5 seconds.
      * @param psk Optional Pre Shared Key (AES-128)
@@ -159,6 +170,7 @@ public:
                      int overhead,
                      std::shared_ptr<NetworkConnection>& ctx,
                      int mtu,
+                     bool failOnConnectionError,
                      int32_t peerIdleTimeout = 5000,
                      const std::string& psk = "");
 

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -130,7 +130,8 @@ public:
 
     /**
      *
-     * Starts an SRT Client with a specified local address to bind to
+     * Starts an SRT Client with a specified local address to bind to and connects to the server. If the server is
+     * currently not listening for connections, the client will keep on trying to re-connect.
      *
      * @param host Remote host IP or hostname to connect to
      * @param port Remote host port to connect to
@@ -144,7 +145,8 @@ public:
      * @param peerIdleTimeout Optional Connection considered broken if no packet received before this timeout.
      * Defaults to 5 seconds.
      * @param psk Optional Pre Shared Key (AES-128)
-     * @return true if configuration was ok and remote IP port could be resolved, false otherwise
+     * @return true if configuration was accepted and remote IP port could be resolved, false otherwise. It will also
+     * return false in case the connection can be made but the provided PSK doesn't match the PSK on the server.
      */
     bool startClient(const std::string& host,
                      uint16_t port,
@@ -328,4 +330,6 @@ private:
     int mCallerMtu;
     int32_t mCallerPeerIdleTimeout;
     std::string mCallerPsk;
+
+    const std::chrono::milliseconds kConnectionTimeout{1000};
 };

--- a/SRTNet.h
+++ b/SRTNet.h
@@ -62,6 +62,15 @@ public:
 
     SRTNet();
 
+    /**
+     *
+     * @brief Constructor that also sets a log handler
+     * @param handler The log handler to be used
+     * @param loglevel The log level to use
+     *
+     **/
+    SRTNet(SRT_LOG_HANDLER_FN* handler, int loglevel);
+
     virtual ~SRTNet();
 
     /**
@@ -218,6 +227,28 @@ public:
     */
     Mode getCurrentMode() const;
 
+    /**
+     *
+     * @brief Default log handler which outputs the message to std::cout
+     * @param opaque not used
+     * @param level the log level of this message
+     * @param file name of the file where this message is logged
+     * @param line line number in the file
+     * @param area not used
+     * @param message the line to be logged
+     *
+     */
+    static void defaultLogHandler(void* opaque, int level, const char* file, int line, const char* area, const char* message);
+
+    /**
+     *
+     * @brief Set log handler
+     * @param handler the new log handler to be used
+     * @param loglevel the log level to use
+     *
+     */
+    void setLogHandler(SRT_LOG_HANDLER_FN* handler, int loglevel);
+
     /// Callback handling connecting clients (only server mode)
     std::function<std::shared_ptr<NetworkConnection>(struct sockaddr& sin,
                                                      SRTSOCKET newSocket,
@@ -257,6 +288,8 @@ private:
     void clientWorker();
 
     void closeAllClientSockets();
+
+    SRT_LOG_HANDLER_FN* logHandler = defaultLogHandler;
 
     // Server active? true == yes
     std::atomic<bool> mServerActive = {false};

--- a/SRTNetInternal.h
+++ b/SRTNetInternal.h
@@ -14,22 +14,28 @@
 #define LOGG_WARN LOG_WARNING
 #define LOGG_ERROR LOG_ERR
 #define LOGG_FATAL LOG_CRIT
-#define LOGG_LEVEL LOGG_NOTIFY //What to logg?
 
 #ifdef DEBUG
 #define SRT_LOGGER(l,g,f) \
 { \
-  if (g <= LOGG_LEVEL) { \
+  if (g <= gLogLevel) { \
     std::ostringstream a; \
-    if (SRTNet::logHandler == SRTNet::defaultLogHandler) { \
-      if (g == LOGG_NOTIFY) {a << "Notification: ";}             \
-      else if (g == LOGG_WARN) {a << "Warning: ";} \
-      else if (g == LOGG_ERROR) {a << "Error: ";} \
-      else if (g == LOGG_FATAL) {a << "Fatal: ";} \
+    if (SRTNet::gLogHandler == SRTNet::defaultLogHandler) { \
+      if (g == LOG_DEBUG) {a << "Debug: ";} \
+      else if (g == LOG_INFO) {a << "Info: ";} \
+      else if (g == LOG_NOTICE) {a << "Notification: ";} \
+      else if (g == LOG_WARNING) {a << "Warning: ";} \
+      else if (g == LOG_ERR) {a << "Error: ";} \
+      else if (g == LOG_CRIT) {a << "Critical: ";} \
+      else if (g == LOG_ALERT) {a << "Alert: ";} \
+      else if (g == LOG_EMERG) {a << "Emergency: ";} \
       if (l) {a << __FILE__ << " " << __LINE__ << " ";} \
     } \
+    if (!mLogPrefix.empty()) { \
+      a << mLogPrefix << ": "; \
+    } \
     a << f; \
-    SRTNet::logHandler(nullptr, g, __FILE__, __LINE__, nullptr, a.str().c_str()); \
+    SRTNet::gLogHandler(nullptr, g, __FILE__, __LINE__, nullptr, a.str().c_str()); \
   } \
 }
 #else

--- a/SRTNetInternal.h
+++ b/SRTNetInternal.h
@@ -10,22 +10,22 @@
 #include <sys/syslog.h>
 
 // Global Logger -- Start
-#define LOGG_NOTIFY 1
-#define LOGG_WARN 2
-#define LOGG_ERROR 4
-#define LOGG_FATAL 8
-#define LOGG_MASK  LOGG_NOTIFY | LOGG_WARN | LOGG_ERROR | LOGG_FATAL //What to logg?
+#define LOGG_NOTIFY LOG_NOTICE
+#define LOGG_WARN LOG_WARNING
+#define LOGG_ERROR LOG_ERR
+#define LOGG_FATAL LOG_CRIT
+#define LOGG_LEVEL LOGG_NOTIFY //What to logg?
 
 #ifdef DEBUG
 #define SRT_LOGGER(l,g,f) \
 { \
-  if (g & LOGG_MASK) { \
+  if (g <= LOGG_LEVEL) { \
     std::ostringstream a; \
     if (SRTNet::logHandler == SRTNet::defaultLogHandler) { \
-      if (g == (LOGG_NOTIFY & (LOGG_MASK))) {a << "Notification: ";} \
-      else if (g == (LOGG_WARN & (LOGG_MASK))) {a << "Warning: ";} \
-      else if (g == (LOGG_ERROR & (LOGG_MASK))) {a << "Error: ";} \
-      else if (g == (LOGG_FATAL & (LOGG_MASK))) {a << "Fatal: ";} \
+      if (g == LOGG_NOTIFY) {a << "Notification: ";}             \
+      else if (g == LOGG_WARN) {a << "Warning: ";} \
+      else if (g == LOGG_ERROR) {a << "Error: ";} \
+      else if (g == LOGG_FATAL) {a << "Fatal: ";} \
       if (l) {a << __FILE__ << " " << __LINE__ << " ";} \
     } \
     a << f; \

--- a/SRTNetInternal.h
+++ b/SRTNetInternal.h
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <sys/syslog.h>
 
 // Global Logger -- Start
 #define LOGG_NOTIFY 1
@@ -18,16 +19,18 @@
 #ifdef DEBUG
 #define SRT_LOGGER(l,g,f) \
 { \
-std::ostringstream a; \
-if (g == (LOGG_NOTIFY & (LOGG_MASK))) {a << "Notification: ";} \
-else if (g == (LOGG_WARN & (LOGG_MASK))) {a << "Warning: ";} \
-else if (g == (LOGG_ERROR & (LOGG_MASK))) {a << "Error: ";} \
-else if (g == (LOGG_FATAL & (LOGG_MASK))) {a << "Fatal: ";} \
-if (a.str().length()) { \
-if (l) {a << __FILE__ << " " << __LINE__ << " ";} \
-a << f << std::endl; \
-std::cout << a.str(); \
-} \
+  if (g & LOGG_MASK) { \
+    std::ostringstream a; \
+    if (SRTNet::logHandler == SRTNet::defaultLogHandler) { \
+      if (g == (LOGG_NOTIFY & (LOGG_MASK))) {a << "Notification: ";} \
+      else if (g == (LOGG_WARN & (LOGG_MASK))) {a << "Warning: ";} \
+      else if (g == (LOGG_ERROR & (LOGG_MASK))) {a << "Error: ";} \
+      else if (g == (LOGG_FATAL & (LOGG_MASK))) {a << "Fatal: ";} \
+      if (l) {a << __FILE__ << " " << __LINE__ << " ";} \
+    } \
+    a << f; \
+    SRTNet::logHandler(nullptr, g, __FILE__, __LINE__, nullptr, a.str().c_str()); \
+  } \
 }
 #else
 #define SRT_LOGGER(l,g,f)

--- a/main.cpp
+++ b/main.cpp
@@ -193,7 +193,7 @@ int main(int argc, const char *argv[]) {
 
     gSRTNetClient1.receivedData = std::bind(&handleDataClient, std::placeholders::_1, std::placeholders::_2,
                                             std::placeholders::_3, std::placeholders::_4);
-    if (!gSRTNetClient1.startClient("127.0.0.1", 8000, 16, 1000, 100, lClient1Connection, 1456, 5000,
+    if (!gSRTNetClient1.startClient("127.0.0.1", 8000, 16, 1000, 100, lClient1Connection, 1456, true, 5000,
                                     "Th1$_is_4_0pt10N4L_P$k")) {
         std::cout << "SRT client1 failed starting." << std::endl;
         return EXIT_FAILURE;
@@ -205,7 +205,7 @@ int main(int argc, const char *argv[]) {
     lClient2Connection->mObject = std::move(lpMyClass2);
     gSRTNetClient2.receivedData = std::bind(&handleDataClient, std::placeholders::_1, std::placeholders::_2,
                                             std::placeholders::_3, std::placeholders::_4);
-    if (!gSRTNetClient2.startClient("127.0.0.1", 8000, 16, 1000, 100, lClient2Connection, 1456, 5000,
+    if (!gSRTNetClient2.startClient("127.0.0.1", 8000, 16, 1000, 100, lClient2Connection, 1456, true, 5000,
                                     "Th1$_is_4_0pt10N4L_P$k")) {
         std::cout << "SRT client2 failed starting." << std::endl;
         return EXIT_FAILURE;

--- a/main.cpp
+++ b/main.cpp
@@ -217,10 +217,8 @@ int main(int argc, const char *argv[]) {
     //  std::cout << "The server got " << clients->mClientList->size() << " clients." << std::endl;
     //  clients = nullptr;
 
-    gSRTNetServer.getActiveClients([](std::map<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> &clientList) {
-                                       std::cout << "The server got " << clientList.size() << " client(s)." << std::endl;
-                                   }
-    );
+    std::vector<SRTSOCKET> clientList = gSRTNetServer.getActiveClientSockets();
+    std::cout << "The server got " << clientList.size() << " client(s)." << std::endl;
 
     //Send 300 packets with 10 milliseconds spacing. Packets are 1000 bytes long
     int lTimes = 0;
@@ -272,10 +270,9 @@ int main(int argc, const char *argv[]) {
     //SRT_TRACEBSTATS lCurrentServerStats = {0};
     //mySRTNetServer.getStatistics(&currentServerStats,SRTNetClearStats::yes,SRTNetInstant::no);
 
-    gSRTNetServer.getActiveClients([](std::map<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> &rClientList) {
-                                       std::cout << "The server got " << rClientList.size() << " clients." << std::endl;
-                                   }
-    );
+    clientList = gSRTNetServer.getActiveClientSockets();
+    std::cout << "The server got " << clientList.size() << " client(s)." << std::endl;
+
 
     std::cout << "SRT garbage collect" << std::endl;
     gSRTNetServer.stop();
@@ -285,10 +282,8 @@ int main(int argc, const char *argv[]) {
     std::cout << "stopClient 2" << std::endl;
     gSRTNetClient2.stop();
 
-    gSRTNetServer.getActiveClients([](std::map<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>> &clientList) {
-                                       std::cout << "The server got " << clientList.size() << " clients." << std::endl;
-                                   }
-    );
+    clientList = gSRTNetServer.getActiveClientSockets();
+    std::cout << "The server got " << clientList.size() << " client(s)." << std::endl;
 
     srt_cleanup();
     std::cout << "SRT wrapper did end." << std::endl;

--- a/test/TestSrt.cpp
+++ b/test/TestSrt.cpp
@@ -173,8 +173,8 @@ TEST(TestSrt, StartStop) {
         ASSERT_TRUE(successfulWait) << "Timeout waiting for client to connect";
     }
 
-    waitUntil([&]() { return !server.getActiveClients().empty(); },
-        std::chrono::seconds(1), std::chrono::milliseconds(10));
+    ASSERT_TRUE(waitUntil([&]() { return !server.getActiveClientSockets().empty(); },
+        std::chrono::seconds(1), std::chrono::milliseconds(10)));
 
     const auto activeClients = server.getActiveClients();
     size_t nClients = activeClients.size();
@@ -466,8 +466,8 @@ TEST_F(TestSRTFixture, SingleSender) {
     ASSERT_TRUE(mClient.isConnectedToServer());
 
     ASSERT_TRUE(waitForClientToConnect(std::chrono::seconds(2)));
-    waitUntil([&]() { return !mServer.getActiveClients().empty(); },
-              std::chrono::seconds(1), std::chrono::milliseconds(10));
+    ASSERT_TRUE(waitUntil([&]() { return !mServer.getActiveClientSockets().empty(); },
+                          std::chrono::seconds(1), std::chrono::milliseconds(10)));
 
     auto activeClients = mServer.getActiveClients();
     size_t numberOfClients = activeClients.size();
@@ -513,8 +513,8 @@ TEST_F(TestSRTFixture, BindAddressForCaller) {
 
 
     ASSERT_TRUE(waitForClientToConnect(std::chrono::seconds(2)));
-    waitUntil([&]() { return !mServer.getActiveClients().empty(); },
-              std::chrono::seconds(1), std::chrono::milliseconds(10));
+    ASSERT_TRUE(waitUntil([&]() { return !mServer.getActiveClientSockets().empty(); },
+                          std::chrono::seconds(1), std::chrono::milliseconds(10)));
 
     const auto activeClients = mServer.getActiveClients();
     size_t numberOfClients = activeClients.size();
@@ -561,8 +561,9 @@ TEST_F(TestSRTFixture, AutomaticPortSelection) {
     EXPECT_GT(clientIPAndPort.second, 1024); // We expect it won't pick a privileged port
     EXPECT_NE(clientIPAndPort.second, serverIPAndPort.second);
 
-    waitUntil([&]() { return !mServer.getActiveClients().empty(); },
-              std::chrono::seconds(1), std::chrono::milliseconds(10));
+    ASSERT_TRUE(waitUntil([&]() { return !mServer.getActiveClientSockets().empty(); },
+                          std::chrono::seconds(1), std::chrono::milliseconds(10)));
+
     const auto activeClients = mServer.getActiveClients();
     size_t nClients = activeClients.size();
 

--- a/test/TestSrt.cpp
+++ b/test/TestSrt.cpp
@@ -214,11 +214,8 @@ TEST(TestSrt, TestPsk) {
     server.clientConnected = [&](struct sockaddr& sin, SRTSOCKET newSocket,
                                  std::shared_ptr<SRTNet::NetworkConnection>& ctx) { return ctx; };
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));
-    EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kInvalidPsk))
-        << "Expected to be able to start client, but not connect when using incorrect PSK";
-    EXPECT_FALSE(client.isClientConnected())
+    EXPECT_FALSE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kInvalidPsk))
         << "Expect to fail when using incorrect PSK";
-    EXPECT_TRUE(client.stop());
 
     ASSERT_TRUE(server.stop());
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));

--- a/test/TestSrt.cpp
+++ b/test/TestSrt.cpp
@@ -112,8 +112,11 @@ TEST(TestSrt, StartStop) {
         << "Expect to fail without providing clientConnected callback";
     auto clientCtx = std::make_shared<SRTNet::NetworkConnection>();
     clientCtx->mObject = 42;
-    EXPECT_FALSE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, clientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk))
+    EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, clientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk))
+        << "Expect client to start, but not be able to connect with no server started";
+    EXPECT_FALSE(client.isClientConnected())
         << "Expect to fail with no server started";
+    EXPECT_TRUE(client.stop());
 
     std::condition_variable connectedCondition;
     std::mutex connectedMutex;
@@ -135,6 +138,7 @@ TEST(TestSrt, StartStop) {
     ASSERT_TRUE(
         server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, serverCtx));
     ASSERT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, clientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(client.isClientConnected());
 
     // check for client connecting
     {
@@ -184,6 +188,7 @@ TEST(TestSrt, StartStop) {
     connected = false;
     SRTNet client2;
     ASSERT_TRUE(client2.startClient("127.0.0.1", 8009, 16, 1000, 100, clientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(client2.isClientConnected());
     // check for client connecting
     {
         std::unique_lock<std::mutex> lock(connectedMutex);
@@ -209,17 +214,22 @@ TEST(TestSrt, TestPsk) {
     server.clientConnected = [&](struct sockaddr& sin, SRTSOCKET newSocket,
                                  std::shared_ptr<SRTNet::NetworkConnection>& ctx) { return ctx; };
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));
-    EXPECT_FALSE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kInvalidPsk))
+    EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kInvalidPsk))
+        << "Expected to be able to start client, but not connect when using incorrect PSK";
+    EXPECT_FALSE(client.isClientConnected())
         << "Expect to fail when using incorrect PSK";
+    EXPECT_TRUE(client.stop());
 
     ASSERT_TRUE(server.stop());
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));
     EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(client.isClientConnected());
 
     ASSERT_TRUE(server.stop());
     ASSERT_TRUE(client.stop());
     ASSERT_TRUE(server.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, "", false, ctx));
     EXPECT_TRUE(client.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE));
+    ASSERT_TRUE(client.isClientConnected());
 }
 
 TEST_F(TestSRTFixture, SendReceive) {
@@ -227,6 +237,7 @@ TEST_F(TestSRTFixture, SendReceive) {
     ASSERT_TRUE(
         mServer.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, mServerCtx));
     ASSERT_TRUE(mClient.startClient("127.0.0.1", 8009, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(mClient.isClientConnected());
 
     std::vector<uint8_t> sendBuffer(1000);
     std::condition_variable serverCondition;
@@ -299,6 +310,7 @@ TEST_F(TestSRTFixture, SendReceiveIPv6) {
     // start server and client
     ASSERT_TRUE(mServer.startServer("::", 8020, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, "", true, mServerCtx));
     ASSERT_TRUE(mClient.startClient("::1", 8020, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, ""));
+    ASSERT_TRUE(mClient.isClientConnected());
 
     std::vector<uint8_t> sendBuffer(1000);
     std::condition_variable serverCondition;
@@ -372,6 +384,7 @@ TEST_F(TestSRTFixture, LargeMessage) {
     ASSERT_TRUE(
         mServer.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, mServerCtx));
     ASSERT_TRUE(mClient.startClient("127.0.0.1", 8009, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(mClient.isClientConnected());
 
     std::vector<uint8_t> sendBuffer(kMaxMessageSize + 1);
     std::fill(sendBuffer.begin(), sendBuffer.end(), 1);
@@ -385,7 +398,7 @@ TEST_F(TestSRTFixture, DISABLED_RejectConnection) {
     EXPECT_TRUE(mServer.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, ctx));
     EXPECT_FALSE(mClient.startClient("127.0.0.1", 8009, 16, 1000, 100, ctx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk))
         << "Expected client connection rejected";
-
+    
     ASSERT_TRUE(waitForClientToConnect(std::chrono::seconds(2)));
 
     auto numberOfClients = 0;
@@ -429,6 +442,7 @@ TEST_F(TestSRTFixture, SingleSender) {
     ASSERT_TRUE(
         mServer.startServer("127.0.0.1", 8009, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, true, mServerCtx));
     ASSERT_TRUE(mClient.startClient("127.0.0.1", 8009, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_TRUE(mClient.isClientConnected());
 
     ASSERT_TRUE(waitForClientToConnect(std::chrono::seconds(2)));
 
@@ -452,8 +466,10 @@ TEST_F(TestSRTFixture, SingleSender) {
     // start a new client, should fail since we only accept one single client
     mConnected = false;
     SRTNet client2;
-    ASSERT_FALSE(
+    ASSERT_TRUE(
         client2.startClient("127.0.0.1", 8009, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    EXPECT_FALSE(client2.isClientConnected())
+        << "Expect to not be able to connect a second client when server just accepts one client";
 
     mServer.getActiveClients([&](std::map<SRTSOCKET, std::shared_ptr<SRTNet::NetworkConnection>>& activeClients) {
         numberOfClients = activeClients.size();
@@ -473,6 +489,8 @@ TEST_F(TestSRTFixture, BindAddressForCaller) {
         mServer.startServer("127.0.0.1", 8010, 16, 1000, 100, SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk, false, mServerCtx));
     ASSERT_TRUE(mClient.startClient("127.0.0.1", 8010, "0.0.0.0", 8011, 16, 1000, 100, mClientCtx, SRT_LIVE_MAX_PLSIZE,
                                    5000, kValidPsk));
+    ASSERT_TRUE(mClient.isClientConnected());
+
 
     ASSERT_TRUE(waitForClientToConnect(std::chrono::seconds(2)));
 
@@ -562,6 +580,7 @@ TEST_F(TestSRTFixture, FailToBindWhenLocalIPIsCorrupt) {
 TEST_F(TestSRTFixture, FailToConnectWhenRemoteHostnameIsCorrupt) {
     uint16_t kPort = 8023;
     std::string kIllFormattedIP = "thi$i$not_a(host)name.com";
-    ASSERT_FALSE(mClient.startClient(kIllFormattedIP, kPort, 16, 1000, 100, mClientCtx,
+    EXPECT_FALSE(mClient.startClient(kIllFormattedIP, kPort, 16, 1000, 100, mClientCtx,
                                      SRT_LIVE_MAX_PLSIZE, 5000, kValidPsk));
+    ASSERT_FALSE(mClient.isClientConnected());                                     
 }


### PR DESCRIPTION
Suggestion of a way to pass SRT library version from client and the negotiated latency back to the user of SRTNet.

We can then extend our logs from for example:
`[2024-05-07 16:19:00.737] [LD_Pipeline] [acl-renderingen-771773] [info]  program 1: Client connected to server: 127.0.0.1:4567`
to:
`[2024-05-07 16:19:00.737] [LD_Pipeline] [acl-renderingen-771773] [info]  program 1: Client connected to server: 127.0.0.1:4567, SRT version: 1.4.4, latency: 3098`
